### PR TITLE
docs: add CHANGELOG.md (Keep a Changelog + SemVer 2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial scaffold — OOD compute adapter for AWS SageMaker Studio, translating Open OnDemand interactive app requests to SageMaker API calls and returning presigned Studio URLs.
+- CLI commands: `launch` (create a SageMaker app → presigned Studio URL), `status <app-id>` (OOD-normalized status), and `delete <app-id>` (delete a Studio app).
+- Substrate integration tests for the SageMaker Studio app lifecycle.
+- CI workflow with pinned action SHAs.


### PR DESCRIPTION
Adds `CHANGELOG.md` adopting the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) + [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) convention used across the rest of the project ecosystem (`oidc-pam`, `aws-hubzero`, `substrate`, `aws-openondemand`).

This repo is pre-release (no tags yet), so all current work is recorded under `## [Unreleased]`. The entries are derived from the existing commit history and README — no code changes.