### PR TITLE
fix: wait for app InService before returning presigned URL (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `launch` now waits for the SageMaker app to reach `InService` (polling `DescribeApp`,
+  bounded by `--wait-timeout`, default 5m) before returning the presigned Studio URL.
+  Previously the URL was generated immediately after `CreateApp`, so it often opened to a
+  Studio loading spinner that timed out (#2). Errors out on a terminal non-serviceable
+  status or on timeout.
+
+### Fixed
 - Repinned `github.com/scttfrdmn/substrate` 0.45.2 → 0.65.0 and regenerated go.sum. The v0.45.2 tag content was changed upstream (substrate#296), so the recorded checksum no longer matched and `go test -tags=integration` failed with a go.sum SECURITY ERROR. Integration tests now build and pass.
 
 ### Added

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -5,11 +5,51 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
+	smtypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/scttfrdmn/ood-sagemaker-adapter/internal/ood"
 	"github.com/scttfrdmn/ood-sagemaker-adapter/internal/sagemaker"
 	"github.com/spf13/cobra"
 )
+
+var waitTimeout time.Duration
+
+// appReadyState classifies a SageMaker AppStatus for the launch wait loop:
+// "ready" once InService, "failed" on a terminal non-serviceable state, else
+// "pending" (keep waiting). Pure function — unit-tested.
+func appReadyState(status smtypes.AppStatus) string {
+	switch status {
+	case smtypes.AppStatusInService:
+		return "ready"
+	case smtypes.AppStatusFailed, smtypes.AppStatusDeleting, smtypes.AppStatusDeleted:
+		return "failed"
+	default: // Pending (and any unknown future value) — keep waiting
+		return "pending"
+	}
+}
+
+// waitForInService polls DescribeApp until the app is InService, errors on a
+// terminal non-serviceable status, or times out.
+func waitForInService(ctx context.Context, client *sagemaker.Client, did, profile, appName, aType string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := client.DescribeApp(ctx, did, profile, appName, aType)
+		if err != nil {
+			return err
+		}
+		switch appReadyState(out.Status) {
+		case "ready":
+			return nil
+		case "failed":
+			return fmt.Errorf("SageMaker app %q entered non-serviceable status %q", appName, out.Status)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for SageMaker app %q to reach InService (last status: %s)", timeout, appName, out.Status)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
 
 var launchCmd = &cobra.Command{
 	Use:   "launch",
@@ -52,6 +92,13 @@ var launchCmd = &cobra.Command{
 			return err
 		}
 
+		// Wait for the app to reach InService before generating the presigned URL.
+		// CreatePresignedDomainUrl succeeds immediately, but a URL handed back before
+		// the app is serviceable opens to a Studio spinner that times out (#2).
+		if err := waitForInService(ctx, client, did, profile, appName, aType, waitTimeout); err != nil {
+			return err
+		}
+
 		url, err := client.CreatePresignedURL(ctx, did, profile)
 		if err != nil {
 			return err
@@ -67,5 +114,7 @@ var launchCmd = &cobra.Command{
 }
 
 func init() {
+	launchCmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 5*time.Minute,
+		"how long to wait for the SageMaker app to reach InService before returning the presigned URL")
 	rootCmd.AddCommand(launchCmd)
 }

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	smtypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+)
+
+func TestAppReadyState(t *testing.T) {
+	tests := []struct {
+		status smtypes.AppStatus
+		want   string
+	}{
+		{smtypes.AppStatusInService, "ready"},
+		{smtypes.AppStatusPending, "pending"},
+		{smtypes.AppStatusFailed, "failed"},
+		{smtypes.AppStatusDeleting, "failed"},
+		{smtypes.AppStatusDeleted, "failed"},
+		{smtypes.AppStatus("SomeFutureStatus"), "pending"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if got := appReadyState(tt.status); got != tt.want {
+				t.Errorf("appReadyState(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2.

## Problem
`launch` called `CreateApp` then **immediately** `CreatePresignedURL`. The URL is valid but the app may not be `InService` yet, so clicking it in OOD opens a Studio spinner that times out.

## Fix
Poll `DescribeApp` until `AppStatus == InService` before generating the URL, bounded by a new `--wait-timeout` flag (default 5m). Error out on a terminal non-serviceable status (`Failed`/`Deleting`/`Deleted`) or on timeout. Reuses the existing `DescribeApp` client method.

## Verification
- `go build`/`go vet`/`go test` pass; new table-driven test for `appReadyState`
- `launch --help` shows `--wait-timeout` (default 5m0s)
- empty stdin still errors gracefully